### PR TITLE
fix(): set font color to black, adjust mac dark theme

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from UI import Ui_widget
 from Widget import RoundedWindow
 from PyQt5.QtWidgets import QPushButton
 
-FILE_PATH = rf'{getenv("APPDATA")}\count_buff\data.json'
+FILE_PATH = r'{}'.format(path.join(getenv("APPDATA", ""), "count_buff", "data.json"))
 UI = Ui_widget()
 BASIC_DATA = {
     'nai_ma': {

--- a/main.py
+++ b/main.py
@@ -776,6 +776,7 @@ def del_button():
 if __name__ == '__main__':
     app = QApplication(argv)
     main_window = RoundedWindow()
+    main_window.setStyleSheet("color: rgb(0, 0, 0);\n")
     UI.setupUi(main_window)
     main_window.setWindowTitle(' 奶量计算器')
     # 要检查的输入框


### PR DESCRIPTION
<img width="1135" alt="image" src="https://github.com/Vixiu/count_buff/assets/45249106/b079b75a-afd6-4004-a63a-f1b347d3f6a2">

开启深色主题后，字体颜色默认白色，看不见了